### PR TITLE
Optimised shell code

### DIFF
--- a/main.tmux
+++ b/main.tmux
@@ -8,9 +8,8 @@ TK_TOGGLE_BIND="$(tmux_option_or_fallback "@keylocker-toggle-bind" "C-g")"
 TK_LOCK_BIND="$(tmux_option "@keylocker-lock-bind")"
 TK_UNLOCK_BIND="$(tmux_option "@keylocker-unlock-bind")"
 
-TMUX_UID="$(tmux display-message -p "#{uid}")"
-SERVER="$(basename "$(tmux display-message -p "#{socket_path}")")"
-DATA="/tmp/tmux-keylocker-$TMUX_UID/$SERVER"
+SOCKET_PATH=$(tmux display-message -p "#{socket_path}")
+DATA="/tmp/tmux-keylocker-${SOCKET_PATH#/tmp/tmux-}"
 rm -rf "$DATA"
 
 if ! tmux show-option -g command-alias | grep -q "(?<!un)lock-mappings="; then

--- a/main.tmux
+++ b/main.tmux
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-TK_HOME="$(command cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TK_HOME="$(dirname "${BASH_SOURCE[0]}")"
 
 source "$TK_HOME/scripts/helpers.sh"
 

--- a/main.tmux
+++ b/main.tmux
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-TK_HOME="$(dirname "${BASH_SOURCE[0]}")"
+TK_HOME="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 
 source "$TK_HOME/scripts/helpers.sh"
 

--- a/scripts/lock.sh
+++ b/scripts/lock.sh
@@ -12,4 +12,3 @@ if ! [ -d "$DATA" ]; then
 	grep -E "tmux-(key)?locker/scripts/(unlock)|(toggle)\.sh" "$DATA/un-mapped-keys" >"$DATA/re-mapped-keys"
 	tmux source "$DATA/re-mapped-keys"
 fi
-echo "  [$(hostname)]  " > $SOCKET_PATH-lockstate

--- a/scripts/lock.sh
+++ b/scripts/lock.sh
@@ -12,3 +12,4 @@ if ! [ -d "$DATA" ]; then
 	grep -E "tmux-(key)?locker/scripts/(unlock)|(toggle)\.sh" "$DATA/un-mapped-keys" >"$DATA/re-mapped-keys"
 	tmux source "$DATA/re-mapped-keys"
 fi
+echo "  $(hostname)  " > $SOCKET_PATH-lockstate

--- a/scripts/lock.sh
+++ b/scripts/lock.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-TMUX_UID="$(tmux display-message -p "#{uid}")"
-SERVER="$(basename "$(tmux display-message -p "#{socket_path}")")"
-DATA="/tmp/tmux-keylocker-$TMUX_UID/$SERVER"
+SOCKET_PATH=$(tmux display-message -p "#{socket_path}")
+DATA="/tmp/tmux-keylocker-${SOCKET_PATH#/tmp/tmux-}"
 if ! [ -d "$DATA" ]; then
 	mkdir -p "$DATA"
 	tmux list-keys | grep -- "-T root" >"$DATA/un-mapped-keys"

--- a/scripts/lock.sh
+++ b/scripts/lock.sh
@@ -12,4 +12,4 @@ if ! [ -d "$DATA" ]; then
 	grep -E "tmux-(key)?locker/scripts/(unlock)|(toggle)\.sh" "$DATA/un-mapped-keys" >"$DATA/re-mapped-keys"
 	tmux source "$DATA/re-mapped-keys"
 fi
-echo "  $(hostname)  " > $SOCKET_PATH-lockstate
+echo "  [$(hostname)]  " > $SOCKET_PATH-lockstate

--- a/scripts/toggle.sh
+++ b/scripts/toggle.sh
@@ -3,6 +3,8 @@ SOCKET_PATH=$(tmux display-message -p "#{socket_path}")
 DATA="/tmp/tmux-keylocker-${SOCKET_PATH#/tmp/tmux-}"
 if [ -d "$DATA" ]; then
 	tmux unlock-mappings
+ 	echo "  $(hostname)  " > $SOCKET_PATH-lockstate
 else
 	tmux lock-mappings
+ 	echo "  [$(hostname)]  " > $SOCKET_PATH-lockstate
 fi

--- a/scripts/toggle.sh
+++ b/scripts/toggle.sh
@@ -3,8 +3,6 @@ SOCKET_PATH=$(tmux display-message -p "#{socket_path}")
 DATA="/tmp/tmux-keylocker-${SOCKET_PATH#/tmp/tmux-}"
 if [ -d "$DATA" ]; then
 	tmux unlock-mappings
- 	echo "  $(hostname)  " > $SOCKET_PATH-lockstate
 else
 	tmux lock-mappings
- 	echo "  [$(hostname)]  " > $SOCKET_PATH-lockstate
 fi

--- a/scripts/toggle.sh
+++ b/scripts/toggle.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-TMUX_UID="$(tmux display-message -p "#{uid}")"
-SERVER="$(basename "$(tmux display-message -p "#{socket_path}")")"
-DATA="/tmp/tmux-keylocker-$TMUX_UID/$SERVER"
+SOCKET_PATH=$(tmux display-message -p "#{socket_path}")
+DATA="/tmp/tmux-keylocker-${SOCKET_PATH#/tmp/tmux-}"
 if [ -d "$DATA" ]; then
 	tmux unlock-mappings
 else

--- a/scripts/unlock.sh
+++ b/scripts/unlock.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-TMUX_UID="$(tmux display-message -p "#{uid}")"
-SERVER="$(basename "$(tmux display-message -p "#{socket_path}")")"
-DATA="/tmp/tmux-keylocker-$TMUX_UID/$SERVER"
+SOCKET_PATH=$(tmux display-message -p "#{socket_path}")
+DATA="/tmp/tmux-keylocker-${SOCKET_PATH#/tmp/tmux-}"
 if [ -d "$DATA" ]; then
 	tmux source "$DATA/un-mapped-keys"
 	rm -rf "$DATA"

--- a/scripts/unlock.sh
+++ b/scripts/unlock.sh
@@ -5,4 +5,3 @@ if [ -d "$DATA" ]; then
 	tmux source "$DATA/un-mapped-keys"
 	rm -rf "$DATA"
 fi
-echo "  $(hostname)  " > $SOCKET_PATH-lockstate

--- a/scripts/unlock.sh
+++ b/scripts/unlock.sh
@@ -5,3 +5,4 @@ if [ -d "$DATA" ]; then
 	tmux source "$DATA/un-mapped-keys"
 	rm -rf "$DATA"
 fi
+echo "  $(hostname)  " > $SOCKET_PATH-lockstate


### PR DESCRIPTION
Replaced `TMUX_UID`,`SERVER`,`DATA` with two variables:

> 1. **SOCKET_PATH ::** `#{socket_path}` **::** expands to `/tmp/tmux-1000/default` or `/tmp/tmux-$TMUX_UID/$SERVER`
> 2. **DATA ::** `${SOCKET_PATH#/tmp/tmux-}` **::** this expands the previous variable to `/tmp/tmux-keylocker`+`1000/default` or +`$TMUX_UID/$SERVER`

Removed superfluous commands from the `TK_HOME` variable:
> AFAIK, there's nothing wrong with using just `$(dirname)` for this.
> This is how `tmux display-message "$TK_HOME"` looks after the change:
> ![image](https://github.com/TheSast/tmux-keylocker/assets/99696763/88f561e9-641c-456c-8489-de4411161786)

